### PR TITLE
G4 cmp 628

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-06-12  G4CMP-628 : If ValleyDir 0 0 0, then AddValley Identity Matrix.
+
 2026-06-05  g4cmp-V10-03-00  Avoid FatalExceptions, add QPDiffusion setting.
 2026-06-03  G4CMP-619 : Softened some exception types in Boundary/GeometryUtils
 2026-06-01  G4CMP-593 : Add diffusion time stepper tau for individual lattices

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,7 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
-2026-06-12  G4CMP-628 : If ValleyDir 0 0 0, then AddValley Identity Matrix.
+2026-06-18  G4CMP-628 : If ValleyDir 0 0 0, then AddValley Identity Matrix.
 
 2026-06-05  g4cmp-V10-03-00  Avoid FatalExceptions, add QPDiffusion setting.
 2026-06-03  G4CMP-619 : Softened some exception types in Boundary/GeometryUtils

--- a/library/src/G4CMPIVRateLinear.cc
+++ b/library/src/G4CMPIVRateLinear.cc
@@ -13,6 +13,7 @@
 // 20210908  Use global track position to query field; configure field.
 // 20211003  Use encapsulated G4CMPFieldUtils to get field.
 // 20230829  Rotated E-field to local frame first and changed Mass Multiplication in HV transformation
+// 20260618  G4CMP-628 -- Skip IV scattering (MFP=0) for single valley case.
 
 #include "G4CMPIVRateLinear.hh"
 #include "G4CMPFieldUtils.hh"
@@ -30,7 +31,8 @@
 // Scattering rate is computed from electric field
 
 G4double G4CMPIVRateLinear::Rate(const G4Track& aTrack) const {
-  // No scattering if track is below threshold
+  // No scattering if single valley or track is below threshold
+  if (theLattice->NumberOfValleys() < 2) return 0.;
   if (Threshold(GetKineticEnergy(aTrack)) > 0.) return 0.;
 
   G4ThreeVector fieldVector = G4CMP::GetFieldAtPosition(aTrack);

--- a/library/src/G4CMPIVRateQuadratic.cc
+++ b/library/src/G4CMPIVRateQuadratic.cc
@@ -16,6 +16,7 @@
 // 20230829  Rotated E-field to local frame first and changed Mass
 //	       Multiplication in HV transformation
 // 20250515  Apply IV energy thresholds to reduce zero-voltage scatters
+// 20260618  G4CMP-628 -- Skip IV scattering (Rate=0) for single valley case.
 
 #include "G4CMPIVRateQuadratic.hh"
 #include "G4CMPFieldUtils.hh"
@@ -36,7 +37,8 @@
 // Scattering rate is computed from electric field
 
 G4double G4CMPIVRateQuadratic::Rate(const G4Track& aTrack) const {
-  // No scattering if track is below threshold
+  // No scattering if single valley or track is below threshold
+  if (theLattice->NumberOfValleys() < 2) return 0.;
   if (Threshold(GetKineticEnergy(aTrack)) > 0.) return 0.;
 
   G4ThreeVector fieldVector = G4CMP::GetFieldAtPosition(aTrack);

--- a/library/src/G4CMPInterValleyRate.cc
+++ b/library/src/G4CMPInterValleyRate.cc
@@ -12,6 +12,7 @@
 // 20170830  Follow Jacoboni, with unified D0/D1 expression and units; drop
 //		acoustic rate, as it is _intra_valley.
 // 20170919  Add interface for threshold identification
+// 20260618  G4CMP-628 -- Skip IV scattering (MFP=0) for single valley case.
 
 #include "G4CMPInterValleyRate.hh"
 #include "G4LatticePhysical.hh"
@@ -51,6 +52,9 @@ LoadDataForTrack(const G4Track* track, const G4bool /*overrideMomentumReset*/) {
 
 G4double G4CMPInterValleyRate::Rate(const G4Track& aTrack) const {
   const_cast<G4CMPInterValleyRate*>(this)->LoadDataForTrack(&aTrack);
+
+  // No scattering if single valley or track is below threshold
+  if (theLattice->NumberOfValleys() < 2) return 0.;
 
   // Initialize numerical buffers
   eTrk = GetKineticEnergy(aTrack);

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -60,6 +60,7 @@
 // 20240510  E. Michhaud -- Add function to compute L0 from other parameters
 // 20250904  R. Linehan -- Linking Tcrit to Delta0 for superconductors
 // 20250905  G4CMP-500 -- Removing non-fundamental superconductor parameters
+// 20260612  E. Michaud -- If ValleyDir 0 0 0, then AddValley Identity Matrix
 
 #include "G4LatticeLogical.hh"
 #include "G4CMPPhononKinematics.hh"	// **** THIS BREAKS G4 PORTING ****

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -60,7 +60,7 @@
 // 20240510  E. Michhaud -- Add function to compute L0 from other parameters
 // 20250904  R. Linehan -- Linking Tcrit to Delta0 for superconductors
 // 20250905  G4CMP-500 -- Removing non-fundamental superconductor parameters
-// 20260612  E. Michaud -- If ValleyDir 0 0 0, then AddValley Identity Matrix
+// 20260618  E. Michaud -- If ValleyDir 0 0 0, then AddValley Identity Matrix
 
 #include "G4LatticeLogical.hh"
 #include "G4CMPPhononKinematics.hh"	// **** THIS BREAKS G4 PORTING ****

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -845,7 +845,16 @@ void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec, G4bool antiv
      
   G4double d=-vz*b;
   G4double e=vz*a;
-      
+
+  if ( vdir.mag()<1e-10 ) {
+      vdir = G4ThreeVector(1,0,0);
+      a=0;
+      b=1;
+      d=0;
+      e=0;
+      f=1;
+  }
+
   // Store the valley's rotation matrix, its inverse and the valley's direction
   fValley.resize(fValley.size()+1);
   fValley.back().setRows(vdir, G4ThreeVector(a,b,0), G4ThreeVector(d,e,f));

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -847,13 +847,10 @@ void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec, G4bool antiv
   G4double d=-vz*b;
   G4double e=vz*a;
 
-  if ( vdir.mag()<1e-10 ) {
-      vdir = G4ThreeVector(1,0,0);
-      a=0;
-      b=1;
-      d=0;
-      e=0;
-      f=1;
+  // If vx=vy=vz=0 use Identity matrix
+  if (vdir.mag()<1e-10) {
+    vdir = G4ThreeVector(1,0,0);
+    a=0; b=1; d=0; e=0; f=1;
   }
 
   // Store the valley's rotation matrix, its inverse and the valley's direction

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -849,6 +849,7 @@ void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec, G4bool antiv
 
   // If vx=vy=vz=0 use Identity matrix
   if (vdir.mag()<1e-10) {
+    if (antival) return;
     vdir = G4ThreeVector(1,0,0);
     a=0; b=1; d=0; e=0; f=1;
   }

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -430,12 +430,8 @@ G4bool G4LatticeReader::ProcessValleyDirection() {
 	   << millerj << " " << millerk << G4endl;
 
   G4ThreeVector valleyDirVec(milleri,millerj,millerk);
-
   pLattice->AddValley(valleyDirVec);
-  // if valleyDir 0 0 0, add Identity matrix once (no anti-valley)
-  if (valleyDirVec.mag() > 1e-10) {
-    pLattice->AddValley(-valleyDirVec, true);
-  }
+  pLattice->AddValley(-valleyDirVec, true);
   return psLatfile->good();
 }
 

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -430,9 +430,17 @@ G4bool G4LatticeReader::ProcessValleyDirection() {
 	   << millerj << " " << millerk << G4endl;
 
   G4ThreeVector valleyDirVec(milleri,millerj,millerk);
+
+  // if valleyDir 0 0 0, add Identity matrix once (no anti-valley)
+  if (valleyDirVec.mag() < 1e-10) {
+    pLattice->AddValley(valleyDirVec);
+    return psLatfile->good();
+  }
+  else {
   pLattice->AddValley(valleyDirVec);
   pLattice->AddValley(-valleyDirVec,true);
   return psLatfile->good();
+  }
 }
 
 

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -431,16 +431,12 @@ G4bool G4LatticeReader::ProcessValleyDirection() {
 
   G4ThreeVector valleyDirVec(milleri,millerj,millerk);
 
-  // if valleyDir 0 0 0, add Identity matrix once (no anti-valley)
-  if (valleyDirVec.mag() < 1e-10) {
-    pLattice->AddValley(valleyDirVec);
-    return psLatfile->good();
-  }
-  else {
   pLattice->AddValley(valleyDirVec);
-  pLattice->AddValley(-valleyDirVec,true);
-  return psLatfile->good();
+  // if valleyDir 0 0 0, add Identity matrix once (no anti-valley)
+  if (valleyDirVec.mag() > 1e-10) {
+    pLattice->AddValley(-valleyDirVec, true);
   }
+  return psLatfile->good();
 }
 
 

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -431,7 +431,7 @@ G4bool G4LatticeReader::ProcessValleyDirection() {
 
   G4ThreeVector valleyDirVec(milleri,millerj,millerk);
   pLattice->AddValley(valleyDirVec);
-  pLattice->AddValley(-valleyDirVec, true);
+  pLattice->AddValley(-valleyDirVec,true);
   return psLatfile->good();
 }
 


### PR DESCRIPTION
Small fix so charge transport can be added for materials with conduction band at Gamma (direct gap). With this change, valleyDir 0 0 0 will addValley Identity matrix instead of the faulty (0,0,0   ,0,1,0,   0,0,1).