### PR TITLE
Add sanity check for charge parameters when G4LatticeLogical is created.

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,6 +7,7 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 2026-06-18  G4CMP-633 : Validate consistency of charge parameters in config.txt.
+2026-06-18  G4CMP-636 : Protect IV Threshold() from empty ivEnergy list.
 2026-06-18  G4CMP-637 : Move calculation of L0 from acDeform into LatticeLogical
 2026-06-16  G4CMP-601 : Protect e-h production for undefined bandgap or Epair.
 

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,6 +7,7 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 2026-06-18  G4CMP-633 : Validate consistency of charge parameters in config.txt.
+2026-06-18  G4CMP-637 : Move calculation of L0 from acDeform into LatticeLogical
 2026-06-16  G4CMP-601 : Protect e-h production for undefined bandgap or Epair.
 
 2026-06-12  g4cmp-V10-04-00  New tutorials/examples for RISQ 2026 Workshop.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-06-17  G4CMP-633 : Validate consistency of charge parameters in config.txt.
 2026-06-16  G4CMP-601 : Protect e-h production for undefined bandgap or Epair.
 
 2026-06-12  g4cmp-V10-04-00  New tutorials/examples for RISQ 2026 Workshop.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,7 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
-2026-06-17  G4CMP-633 : Validate consistency of charge parameters in config.txt.
+2026-06-18  G4CMP-633 : Validate consistency of charge parameters in config.txt.
 2026-06-16  G4CMP-601 : Protect e-h production for undefined bandgap or Epair.
 
 2026-06-12  g4cmp-V10-04-00  New tutorials/examples for RISQ 2026 Workshop.

--- a/library/include/G4LatticeLogical.hh
+++ b/library/include/G4LatticeLogical.hh
@@ -45,6 +45,7 @@
 // 20250904  R. Linehan -- Linked Tcrit to Delta0 for superconductors
 // 20250905  G4CMP-500  -- Removed non-fundamental superconductor params from
 //              lattice info
+// 20260617  G4CMP-633 -- Cross-check that sufficient charge parameters are set
 
 #ifndef G4LatticeLogical_h
 #define G4LatticeLogical_h
@@ -309,8 +310,11 @@ private:
   // Use direct calculation to get group velocity for phonons
   G4ThreeVector ComputeKtoVg(G4int mode, const G4ThreeVector& k) const;
 
-  //Do an internal check to make sure that we have all SC parameters
-  void CheckLatticeForSCCompleteness();
+  // Internal check to ensure that we have sufficient charge parameters
+  void CheckLatticeChargeParameters();		// Non-const for AddValley() use
+
+  // Internal check to make sure that we have all SC parameters
+  void CheckLatticeForSCCompleteness() const;
   
 private:
   // Create a thread-local buffer to use with MapAtoB() functions

--- a/library/include/G4LatticeLogical.hh
+++ b/library/include/G4LatticeLogical.hh
@@ -46,6 +46,7 @@
 // 20250905  G4CMP-500  -- Removed non-fundamental superconductor params from
 //              lattice info
 // 20260617  G4CMP-633 -- Cross-check that sufficient charge parameters are set
+// 20260618  G4CMP-637 -- Move calculation of L0 from acDeform out of Manager.
 
 #ifndef G4LatticeLogical_h
 #define G4LatticeLogical_h
@@ -216,9 +217,6 @@ public:
   // Compute "effective mass" for electron to preserve E/p relationship
   G4double GetElectronEffectiveMass(G4int iv, const G4ThreeVector& p) const;
     
-  // Compute "l0" for electron and hole
-  G4double ComputeL0(G4bool IsElec);
-
   G4ThreeVector RotateToValley(G4int iv, const G4ThreeVector& v) const;
   G4ThreeVector RotateFromValley(G4int iv, const G4ThreeVector& v) const;
   G4ThreeVector EllipsoidalToSphericalTranformation(G4int iv, const G4ThreeVector& v) const;
@@ -309,6 +307,9 @@ private:
 
   // Use direct calculation to get group velocity for phonons
   G4ThreeVector ComputeKtoVg(G4int mode, const G4ThreeVector& k) const;
+
+  // Compute scattering length L0 for electrons or hole
+  G4double ComputeL0(G4double mass, G4double acDeform) const;
 
   // Internal check to ensure that we have sufficient charge parameters
   void CheckLatticeChargeParameters();		// Non-const for AddValley() use

--- a/library/src/G4CMPIVRateLinear.cc
+++ b/library/src/G4CMPIVRateLinear.cc
@@ -12,7 +12,9 @@
 // 20181001  Use systematic names for IV rate parameters
 // 20210908  Use global track position to query field; configure field.
 // 20211003  Use encapsulated G4CMPFieldUtils to get field.
-// 20230829  Rotated E-field to local frame first and changed Mass Multiplication in HV transformation
+// 20230829  Rotated E-field to local frame first and changed Mass
+//	       Multiplication in HV transformation
+// 20260618  G4CMP-636 -- Protect Threshold() from empty IVEnergy list.
 
 #include "G4CMPIVRateLinear.hh"
 #include "G4CMPFieldUtils.hh"
@@ -66,8 +68,11 @@ G4double G4CMPIVRateLinear::Rate(const G4Track& aTrack) const {
 // Threshold is minimum energy of any scattering channel
 
 G4double G4CMPIVRateLinear::Threshold(G4double Eabove) const {
+  const std::vector<G4double>& ivEnergy = theLattice->GetIVEnergy();
+
   // NOTE: min_element returns iterator, dereference returns value
-  G4double Emin = *std::min_element(theLattice->GetIVEnergy().begin(),
-				    theLattice->GetIVEnergy().end());
+  G4double Emin = (ivEnergy.empty() ? 0.
+		   : *std::min_element(ivEnergy.begin(), ivEnergy.end()) );
+
   return (Eabove<Emin) ? Emin : 0.;
 }

--- a/library/src/G4CMPIVRateQuadratic.cc
+++ b/library/src/G4CMPIVRateQuadratic.cc
@@ -16,6 +16,7 @@
 // 20230829  Rotated E-field to local frame first and changed Mass
 //	       Multiplication in HV transformation
 // 20250515  Apply IV energy thresholds to reduce zero-voltage scatters
+// 20260618  G4CMP-636 -- Protect Threshold() from empty IVEnergy list.
 
 #include "G4CMPIVRateQuadratic.hh"
 #include "G4CMPFieldUtils.hh"
@@ -73,8 +74,11 @@ G4double G4CMPIVRateQuadratic::Rate(const G4Track& aTrack) const {
 // Threshold is minimum energy of any scattering channel
 
 G4double G4CMPIVRateQuadratic::Threshold(G4double Eabove) const {
+  const std::vector<G4double>& ivEnergy = theLattice->GetIVEnergy();
+
   // NOTE: min_element returns iterator, dereference returns value
-  G4double Emin = *std::min_element(theLattice->GetIVEnergy().begin(),
-				    theLattice->GetIVEnergy().end());
+  G4double Emin = (ivEnergy.empty() ? 0.
+		   : *std::min_element(ivEnergy.begin(), ivEnergy.end()) );
+
   return (Eabove<Emin) ? Emin : 0.;
 }

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -81,7 +81,7 @@ G4LatticeLogical::G4LatticeLogical(const G4String& name)
     fPermittivity(1.), fElasticity{}, fElReduced{}, fHasElasticity(false),
     fpPhononKin(0), fpPhononTable(0),
     fA(0), fB(0), fLDOS(0), fSTDOS(0), fFTDOS(0), fTTFrac(0), 
-    fBeta(0), fGamma(0), fLambda(0), fMu(0),
+    fBeta(0), fGamma(0), fLambda(0), fMu(0), fDebye(0),
     fSC_Tau0_qp(DBL_MAX), fSC_Tau0_ph(DBL_MAX),
     fVSound(0.), fVTrans(0.), fL0_e(0.), fL0_h(0.), 
     mElectron(electron_mass_c2/c_squared),
@@ -1123,8 +1123,6 @@ void G4LatticeLogical::DumpList(std::ostream& os,
 // Check for completeness of charge transport parameters
 
 void G4LatticeLogical::CheckLatticeChargeParameters() {
-  G4bool goodChg = true;
-
   // No bandgap will suppress e/h creation, but allow single tracking
   if (fBandGap <= 0. && fPairEnergy <= 0.) {
     if (verboseLevel) {
@@ -1137,44 +1135,49 @@ void G4LatticeLogical::CheckLatticeChargeParameters() {
   if (fPairEnergy < fBandGap) {
     G4ExceptionDescription msg;
     msg << "Lattice " << fName << " has pair energy " << fPairEnergy/eV
-	<< " eV below bandgap " << fBandGap << " eV.";
+	<< " eV, which is below bandgap " << fBandGap/eV << " eV.";
     G4Exception("G4LatticeLogical", "Lattice008", FatalException, msg);
-    goodChg = false;
   }
 
   // If charge masses are not defined, remind user they're free electrons
-  if (goodChg && (fabs(fElectronMass-mElectron)/mElectron < 1e-3 ||
-		  fabs(fHoleMass-mElectron)/mElectron < 1e-3)) {
+  if (fabs(fElectronMass-mElectron)/mElectron < 1e-3 ||
+      fabs(fHoleMass-mElectron)/mElectron < 1e-3) {
     G4ExceptionDescription msg;
     msg << "Lattice " << fName << " does not have charge carrier masses set."
 	<< "\n Bare electron mass assumed.";
     G4Exception("G4LatticeLogical", "Lattice009", JustWarning, msg);
   }
 
+  // Sensible charge transport must include finite scattering lengths
+  if (fL0_e <= 0. || fL0_h <= 0.) {
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << " has no charge scattering L0 defined.";
+    G4Exception("G4LatticeLogical", "Lattice010", FatalException, msg);
+  }
+
+  // Speed of sound must be defined, to avoid infinite Luke scattering
+  if (fVSound <= 0. && fVTrans <= 0.) {
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << " has no speed of sound defined.";
+    G4Exception("G4LatticeLogical", "Lattice011", FatalException, msg);
+  }
+
   // Without valleys, assume a direct gap semiconductor with Gamma 'valley'
-  if (goodChg && fValley.size() < 1U) {
+  // TODO: Move to CheckIVConsistency() under G4CMP-404
+  if (fValley.size() < 1U) {
     G4cout << "Lattice " << fName << " assuming direct gap semiconductor,"
 	   << " using Gamma valley (0,0,0)." << G4endl;
 
     AddValley(G4ThreeVector(0,0,0));
   }
 
-  // Sensible charge transport must include finite scattering lengths
-  if (goodChg && (fL0_e <= 0. || fL0_h <= 0.)) {
-    G4ExceptionDescription msg;
-    msg << "Lattice " << fName << " has no charge scattering L0 defined.";
-    G4Exception("G4LatticeLogical", "Lattice010", FatalException, msg);
-    goodChg = false;
-  }
-
   // Multiple valleys ought to have IV scattering, but may not
-  if (goodChg && fValley.size() > 1U && fIVModel.empty()) {
+  // TODO: Move to CheckIVConsistency() under G4CMP-404
+  if (fValley.size() > 1U && fIVModel.empty()) {
     G4ExceptionDescription msg;
     msg << "Lattice " << fName << "has no intervalley scattering model.";
-    G4Exception("G4LatticeLogical", "Lattice011", JustWarning, msg);
+    G4Exception("G4LatticeLogical", "Lattice012", JustWarning, msg);
   }
-
-  // TODO: Should we be checking the different IV model parmaeters?
 }
 
 

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -1165,8 +1165,10 @@ void G4LatticeLogical::CheckLatticeChargeParameters() {
   // Without valleys, assume a direct gap semiconductor with Gamma 'valley'
   // TODO: Move to CheckIVConsistency() under G4CMP-404
   if (fValley.size() < 1U) {
-    G4cout << "Lattice " << fName << " assuming direct gap semiconductor,"
-	   << " using Gamma valley (0,0,0)." << G4endl;
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << " has no valley definitions.\n"
+	<< " Assuming direct gap semiconductor with Gamma valley.";
+    G4Exception("G4LatticeLogical", "Lattice012", JustWarning, msg);
 
     AddValley(G4ThreeVector(0,0,0));
   }
@@ -1176,7 +1178,7 @@ void G4LatticeLogical::CheckLatticeChargeParameters() {
   if (fValley.size() > 1U && fIVModel.empty()) {
     G4ExceptionDescription msg;
     msg << "Lattice " << fName << "has no intervalley scattering model.";
-    G4Exception("G4LatticeLogical", "Lattice012", JustWarning, msg);
+    G4Exception("G4LatticeLogical", "Lattice013", JustWarning, msg);
   }
 }
 

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -60,6 +60,7 @@
 // 20240510  E. Michhaud -- Add function to compute L0 from other parameters
 // 20250904  R. Linehan -- Linking Tcrit to Delta0 for superconductors
 // 20250905  G4CMP-500 -- Removing non-fundamental superconductor parameters
+// 20260617  G4CMP-633 -- Cross-check that sufficient charge parameters are set
 
 #include "G4LatticeLogical.hh"
 #include "G4CMPPhononKinematics.hh"	// **** THIS BREAKS G4 PORTING ****
@@ -251,7 +252,10 @@ void G4LatticeLogical::Initialize(const G4String& newName) {
   // Populate phonon lookup tables if not read from files
   FillMaps();
 
-  //Check for completeness of superconducting parameters
+  // Check for completeness of charge transport parameters
+  CheckLatticeChargeParameters();
+
+  // Check for completeness of superconducting parameters
   CheckLatticeForSCCompleteness();
 }
 
@@ -1116,6 +1120,64 @@ void G4LatticeLogical::DumpList(std::ostream& os,
 }
 
 
+// Check for completeness of charge transport parameters
+
+void G4LatticeLogical::CheckLatticeChargeParameters() {
+  G4bool goodChg = true;
+
+  // No bandgap will suppress e/h creation, but allow single tracking
+  if (fBandGap <= 0. && fPairEnergy <= 0.) {
+    if (verboseLevel) {
+      G4cout << "Lattice " << fName << " does not have bandgap or pair energy"
+	     << " defined.  No charge production." << G4endl;
+    }
+  }
+
+  // If bandgap is defined, pair energy must be larger
+  if (fPairEnergy < fBandGap) {
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << " has pair energy " << fPairEnergy/eV
+	<< " eV below bandgap " << fBandGap << " eV.";
+    G4Exception("G4LatticeLogical", "Lattice008", FatalException, msg);
+    goodChg = false;
+  }
+
+  // If charge masses are not defined, remind user they're free electrons
+  if (goodChg && (fabs(fElectronMass-mElectron)/mElectron < 1e-3 ||
+		  fabs(fHoleMass-mElectron)/mElectron < 1e-3)) {
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << " does not have charge carrier masses set."
+	<< "\n Bare electron mass assumed.";
+    G4Exception("G4LatticeLogical", "Lattice009", JustWarning, msg);
+  }
+
+  // Without valleys, assume a direct gap semiconductor with Gamma 'valley'
+  if (goodChg && fValley.size() < 1U) {
+    G4cout << "Lattice " << fName << " assuming direct gap semiconductor,"
+	   << " using Gamma valley (0,0,0)." << G4endl;
+
+    AddValley(G4ThreeVector(0,0,0));
+  }
+
+  // Sensible charge transport must include finite scattering lengths
+  if (goodChg && (fL0_e <= 0. || fL0_h <= 0.)) {
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << " has no charge scattering L0 defined.";
+    G4Exception("G4LatticeLogical", "Lattice010", FatalException, msg);
+    goodChg = false;
+  }
+
+  // Multiple valleys ought to have IV scattering, but may not
+  if (goodChg && fValley.size() > 1U && fIVModel.empty()) {
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << "has no intervalley scattering model.";
+    G4Exception("G4LatticeLogical", "Lattice011", JustWarning, msg);
+  }
+
+  // TODO: Should we be checking the different IV model parmaeters?
+}
+
+
 //This checks the results of the created lattice to understand if all relevant
 //parameters have been added. We can put whatever we want here, but for now I
 //want to say that if any of the superconductor lattice parameters have been
@@ -1123,7 +1185,7 @@ void G4LatticeLogical::DumpList(std::ostream& os,
 //that isn't true, then they should make it true. This forced execution stop
 //occurs here for the "fundamental" parameters and in SCUtils for the "physical-
 //lattice-dependent" ones
-void G4LatticeLogical::CheckLatticeForSCCompleteness() {
+void G4LatticeLogical::CheckLatticeForSCCompleteness() const {
   //Check to see if any of the SC parameters are not at their default values,
   //i.e. if they have been set.
   if (fSC_Tau0_qp != DBL_MAX ||
@@ -1136,12 +1198,9 @@ void G4LatticeLogical::CheckLatticeForSCCompleteness() {
       //Throw a warning that there are outstanding SC parameters that are not
       //set.
       G4ExceptionDescription msg;
-      msg << "Noticed that one or more superconducting film lattice parameters "
-	  << "are set in a config file, but that one or more are also missing. "
-	  << "Please fill in Tau0_qp and Tau0_ph for all superconductors you "
-	  << "want to use before continuing.";
-      G4Exception("G4LatticeLogical::CheckLatticeForSCCompleteness", "Lattice007",
-		  FatalException, msg);
+      msg << "Lattice " << fName << ": Both Tau0_qp and Tau0_ph required"
+	  << " for superconductors.";
+      G4Exception("G4LatticeLogical", "Lattice007", FatalException, msg);
     }
   }  
 }

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -1181,29 +1181,16 @@ void G4LatticeLogical::CheckLatticeChargeParameters() {
 }
 
 
-//This checks the results of the created lattice to understand if all relevant
-//parameters have been added. We can put whatever we want here, but for now I
-//want to say that if any of the superconductor lattice parameters have been
-//added, we want to make sure that all of them have, and alert users that if
-//that isn't true, then they should make it true. This forced execution stop
-//occurs here for the "fundamental" parameters and in SCUtils for the "physical-
-//lattice-dependent" ones
+// Ensure that lattice-defined quasiparticle parameters are consistent
 void G4LatticeLogical::CheckLatticeForSCCompleteness() const {
-  //Check to see if any of the SC parameters are not at their default values,
-  //i.e. if they have been set.
-  if (fSC_Tau0_qp != DBL_MAX ||
-      fSC_Tau0_ph != DBL_MAX) {
-    
-    //If one of these is set, check to see if any of them are NOT set.
-    if (fSC_Tau0_qp == DBL_MAX ||
-	fSC_Tau0_ph == DBL_MAX) {
-      
-      //Throw a warning that there are outstanding SC parameters that are not
-      //set.
-      G4ExceptionDescription msg;
-      msg << "Lattice " << fName << ": Both Tau0_qp and Tau0_ph required"
-	  << " for superconductors.";
-      G4Exception("G4LatticeLogical", "Lattice007", FatalException, msg);
-    }
-  }  
+  // If any of the QP parameters are set, then they all must be set
+  G4bool allOrNone = ( (fSC_Tau0_qp != DBL_MAX && fSC_Tau0_ph != DBL_MAX) ||
+		       (fSC_Tau0_qp == DBL_MAX && fSC_Tau0_ph == DBL_MAX) );
+
+  if (!allOrNone) {   // Terminate job if QP parameters are not consisent
+    G4ExceptionDescription msg;
+    msg << "Lattice " << fName << ": Both Tau0_qp and Tau0_ph required"
+	<< " for superconductors.";
+    G4Exception("G4LatticeLogical", "Lattice007", FatalException, msg);
+  }
 }

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -61,6 +61,7 @@
 // 20250904  R. Linehan -- Linking Tcrit to Delta0 for superconductors
 // 20250905  G4CMP-500 -- Removing non-fundamental superconductor parameters
 // 20260617  G4CMP-633 -- Cross-check that sufficient charge parameters are set
+// 20260618  G4CMP-637 -- Move calculation of L0 from acDeform out of Manager.
 
 #include "G4LatticeLogical.hh"
 #include "G4CMPPhononKinematics.hh"	// **** THIS BREAKS G4 PORTING ****
@@ -251,6 +252,10 @@ void G4LatticeLogical::Initialize(const G4String& newName) {
 
   // Populate phonon lookup tables if not read from files
   FillMaps();
+
+  // Compute charge scattering lengths from theoretical parameters
+  if (fL0_e <= 0.) fL0_e = ComputeL0(fElectronMass, fAcDeform_e);
+  if (fL0_h <= 0.) fL0_h = ComputeL0(fHoleMass, fAcDeform_h);
 
   // Check for completeness of charge transport parameters
   CheckLatticeChargeParameters();
@@ -921,21 +926,13 @@ const G4ThreeVector& G4LatticeLogical::GetValleyAxis(G4int iv) const {
 
 // Process scattering length l0_e and l0_h
 
-G4double G4LatticeLogical::ComputeL0(G4bool IsElec) {
-  G4double mass = 0.;
-  G4double acDeform = 0.;
-      
-  if (IsElec) {
-      mass = GetElectronMass();
-      acDeform = GetElectronAcousticDeform();
-  }
-  else    {
-      mass = GetHoleMass();
-      acDeform = GetHoleAcousticDeform();
-  }
- 
-  G4double l0 = pi*hbar_Planck*hbar_Planck*hbar_Planck*hbar_Planck*fDensity/2/mass/mass/mass/acDeform/acDeform;
-  return l0;
+G4double G4LatticeLogical::ComputeL0(G4double mass, G4double acDeform) const {
+  const G4double hbar4 = hbar_Planck*hbar_Planck*hbar_Planck*hbar_Planck;
+  const G4double mass3 = mass*mass*mass;
+  const G4double ac2 = acDeform*acDeform;
+
+  // If acDeform was not set, return zero scattering length
+  return (acDeform > 0. ? 0.5*pi*hbar4*fDensity/(mass3*ac2) : 0.);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....

--- a/library/src/G4LatticeManager.cc
+++ b/library/src/G4LatticeManager.cc
@@ -21,6 +21,7 @@
 // 20170928  Replace "polarizationState" with "mode"
 // 20250905  G4CMP-500 -- Added warning comment about RegisterLattice
 //                 use with tracked film response
+// 20260618  G4CMP-637 -- Move calculation of L0 into G4LatticeLogical
 
 #include "G4LatticeManager.hh"
 #include "G4CMPConfigManager.hh"
@@ -126,8 +127,6 @@ G4LatticeLogical* G4LatticeManager::LoadLattice(const G4Material* Mat,
   G4LatticeLogical* newLat = latReader.MakeLattice(latDir+"/config.txt");
   if (newLat) {
     newLat->SetDensity(Mat->GetDensity());
-    if (newLat->GetElectronScatter()==0) {newLat->SetElectronScatter(newLat->ComputeL0(true));}
-    if (newLat->GetHoleScatter()==0) {newLat->SetHoleScatter(newLat->ComputeL0(false));}
     newLat->Initialize(latDir);
     if (verboseLevel>1)
       G4cout << " Created newLat " << newLat << "\n" << *newLat << G4endl;


### PR DESCRIPTION
Emile discovered that if we don't explicitly define at least one valley, the `fValley` list is empty, and the result triggers a segmentation fault when new electron tracks are created and can't be assigned a valley index.

For G4CMP-633, I am adding a consistency check as part of `G4LatticeLogical::Initialize()`, to ensure that a minimal set of charge transport parameters are provided.  For the specific issue of `fValley` being empty, I will add a single (0,0,0) valley, corresponding to an isotropic direct bandgap semiconductor.  I am also adding a set of additional checks to let developers know explicitly if their brand new config.txt file is sufficient or broken.

As a side change, I've also done a bit of compressing of Ryan's QP parameter consistency check.