### PR TITLE
G4CMP-647: Base class for quasiparticle-phonon interactions (KaplanQP)

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,7 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
-2026-06-19  g4cmp-C10-04-01  Fixes and sanity checks for partial charge params.
+2026-06-19  g4cmp-V10-04-01  Fixes and sanity checks for partial charge params.
 2026-06-18  G4CMP-628 : If ValleyDir 0 0 0, then AddValley Identity Matrix.
 2026-06-18  G4CMP-634 : Clean up check on valley index for new tracks.
 2026-06-18  G4CMP-633 : Validate consistency of charge parameters in config.txt.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,8 +7,9 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 2026-07-21  G4CMP-649 : Protect against missing touchable in SurfaceClearance.
-2026-07-10  G4CMP-647  Institute base class for phonon-qp interactions.
+2026-07-10  G4CMP-647 : Institute base class for phonon-qp interactions.
 2026-07-07  G4CMP-641 : Update PhysicsModelCatalog usage for G4 11.4.2.
+
 2026-06-19  g4cmp-V10-04-01  Fixes and sanity checks for partial charge params.
 2026-06-18  G4CMP-628 : If ValleyDir 0 0 0, then AddValley Identity Matrix.
 2026-06-18  G4CMP-634 : Clean up check on valley index for new tracks.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-07-21  G4CMP-649 : Protect against missing touchable in SurfaceClearance.
 2026-07-07  G4CMP-641 : Update PhysicsModelCatalog usage for G4 11.4.2.
 
 2026-06-19  g4cmp-V10-04-01  Fixes and sanity checks for partial charge params.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-07-07  G4CMP-641 : Update PhysicsModelCatalog usage for G4 11.4.2.
+
 2026-06-19  g4cmp-V10-04-01  Fixes and sanity checks for partial charge params.
 2026-06-18  G4CMP-628 : If ValleyDir 0 0 0, then AddValley Identity Matrix.
 2026-06-18  G4CMP-634 : Clean up check on valley index for new tracks.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-07-10  G4CMP-647  Institute base class for phonon-qp interactions.
 2026-06-19  g4cmp-V10-04-01  Fixes and sanity checks for partial charge params.
 2026-06-18  G4CMP-628 : If ValleyDir 0 0 0, then AddValley Identity Matrix.
 2026-06-18  G4CMP-634 : Clean up check on valley index for new tracks.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -245,6 +245,7 @@ set(library_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/G4CMPQPLocalTrappingRate.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/G4CMPQPDiffusionTimeStepperProcess.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/G4CMPQPDiffusionTimeStepperRate.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/G4CMPVKaplanQP.cc
     )
  
 set(library_HEADERS
@@ -359,6 +360,7 @@ set(library_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/G4CMPQPLocalTrappingRate.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/include/G4CMPQPDiffusionTimeStepperProcess.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/include/G4CMPQPDiffusionTimeStepperRate.hh
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/G4CMPVKaplanQP.hh
     )
 
 set(config_FILES

--- a/library/include/G4CMPKaplanQP.hh
+++ b/library/include/G4CMPKaplanQP.hh
@@ -53,16 +53,17 @@
 //		new DoDirectAbsorption() boolean test.
 // 20240502  G4CMP-344: Reusable vector buffers to avoid memory churn.
 // 20240502  G4CMP-379: Add Fermi-Dirac thermal probability for QP energies.
+// 20250101  G4CMP-439: Create separate debugging file per worker thread;
+//    add EventID and TrackID columns to debugging output.
+// 20260710  G4CMP-647 -- Derive from new base class G4CMPVKaplanQP
 
 #ifndef G4CMPKaplanQP_hh
 #define G4CMPKaplanQP_hh 1
 
+#include "G4CMPVKaplanQP.hh"
 #include "G4Types.hh"
 #include <fstream>
 #include <vector>
-
-class G4MaterialPropertiesTable;
-
 
 // This is the main function for the Kaplan quasiparticle downconversion
 // process. Based on the energy of the incoming phonon and the properties
@@ -76,124 +77,48 @@ namespace G4CMP {
 			  std::vector<G4double>& reflectedEnergies);
 }
 
-class G4CMPKaplanQP {
+class G4CMPKaplanQP : public G4CMPVKaplanQP {
 public:
   G4CMPKaplanQP(G4MaterialPropertiesTable* prop, G4int vb=0);
-  virtual ~G4CMPKaplanQP();
-
-  // Turn on diagnostic messages
-  void SetVerboseLevel(G4int vb) { verboseLevel = vb; }
-  G4int GetVerboseLevel() const { return verboseLevel; }
 
   // Do absorption on sensor/metalization film
   // Returns absorbed energy, fills list of re-emitted phonons
-  G4double AbsorbPhonon(G4double energy,
-			std::vector<G4double>& reflectedEnergies) const;
-
-  // Set temperature for use by thermalization functions
-  void SetTemperature(G4double temp) { temperature = temp; }
-
-  // Configure thin film (QET, metalization, etc.) for phonon absorption
-  void SetFilmProperties(G4MaterialPropertiesTable* prop);
-
-  // Alternative configuration without properties table
-  void SetFilmThickness(G4double value)       { filmThickness = value; }
-  void SetGapEnergy(G4double value)           { gapEnergy = value; }
-  void SetLowQPLimit(G4double value)          { lowQPLimit = value; }
-  void SetHighQPLimit(G4double value)         { highQPLimit = value; }
-  void SetSubgapAbsorption(G4double value)    { directAbsorption = value; }
-  void SetDirectAbsorption(G4double value)    { directAbsorption = value; }
-  void SetAbsorberGap(G4double value)         { absorberGap = value; }
-  void SetAbsorberEff(G4double value)         { absorberEff = value; }
-  void SetAbsorberEffSlope(G4double value)    { absorberEffSlope = value; }
-  void SetPhononLifetime(G4double value)      { phononLifetime = value; }
-  void SetPhononLifetimeSlope(G4double value) { phononLifetimeSlope = value; }
-  void SetVSound(G4double value)              { vSound = value; }
+  virtual G4double AbsorbPhonon(G4double energy,
+			std::vector<G4double>& reflectedEnergies) const override;
 
 protected:
-  // Check that the five required parameters are set to meaningful values
-  G4bool ParamsReady() const {
-    return (filmThickness > 0. && gapEnergy >= 0. && vSound > 0. &&
-	    phononLifetime > 0. && phononLifetimeSlope >= 0.);
-  }
-
   // Compute the probability of a phonon reentering the crystal without breaking
   // any Cooper pairs.
-  G4double CalcEscapeProbability(G4double energy,
-				 G4double thicknessFrac) const;
+  virtual G4double CalcEscapeProbability(G4double energy,
+				 G4double thicknessFrac) const override;
 
   // Model the phonons (phonEnergies) breaking Cooper pairs into quasiparticles
   // (qpEnergies).
-  G4double CalcQPEnergies(std::vector<G4double>& phonEnergies,
-			  std::vector<G4double>& qpEnergies) const;
+  virtual G4double CalcQPEnergies(std::vector<G4double>& phonEnergies,
+			  std::vector<G4double>& qpEnergies) const override;
   
   // Model the quasiparticles (qpEnergies) emitting phonons (phonEnergies) in
   // the superconductor.
-  G4double CalcPhononEnergies(std::vector<G4double>& phonEnergies,
-			      std::vector<G4double>& qpEnergies) const;
+  virtual G4double CalcPhononEnergies(std::vector<G4double>& phonEnergies,
+			      std::vector<G4double>& qpEnergies) const override;
   
   // Calculate energies of phonon tracks that have reentered the crystal.
-  void CalcReflectedPhononEnergies(std::vector<G4double>& phonEnergies,
-				   std::vector<G4double>& reflectedEnergies) const;
+  virtual void CalcReflectedPhononEnergies(std::vector<G4double>& phonEnergies,
+				   std::vector<G4double>& reflectedEnergies) const override;
 
   // Compute probability of phonon collection directly on absorber (TES)
-  G4bool DoDirectAbsorption(G4double energy) const;
-  G4double CalcDirectAbsorption(G4double energy,
-				std::vector<G4double>& keepEnergies) const;
+  virtual G4bool DoDirectAbsorption(G4double energy) const override;
+  virtual G4double CalcDirectAbsorption(G4double energy,
+				std::vector<G4double>& keepEnergies) const override;
 
   // Handle absorption of quasiparticle energies below Cooper-pair breaking
   // If qpEnergy < 3*Delta, radiate a phonon, absorb bandgap minimum
-  G4double CalcQPAbsorption(G4double energy,
+  virtual G4double CalcQPAbsorption(G4double energy,
 			    std::vector<G4double>& phonEnergies,
-			    std::vector<G4double>& qpEnergies) const;
+			    std::vector<G4double>& qpEnergies) const override;
 			    
   // Handle quasiparticle energy-dependent absorption efficiency
-  G4double CalcQPEfficiency(G4double qpE) const;
-
-  // Compute quasiparticle energy distribution from broken Cooper pair.
-  G4double QPEnergyRand(G4double Energy) const;
-  G4double QPEnergyPDF(G4double E, G4double x) const;
-  G4double ThermalPDF(G4double E) const;
-
-  // Compute phonon energy distribution from quasiparticle in superconductor.
-  G4double PhononEnergyRand(G4double Energy) const;
-  G4double PhononEnergyPDF(G4double E, G4double x) const;
-
-  // Encapsulate below-bandgap logic
-  G4bool IsSubgap(G4double energy) const { return (energy < 2.*gapEnergy); }
-  G4bool DirectAbsorb(G4double energy) const {
-    return (IsSubgap(energy) && energy > 2.*absorberGap);
-  }
-
-  // Write summary of interaction to output "kaplanqp_stats" file
-  void ReportAbsorption(G4double energy, G4double EDep,
-			const std::vector<G4double>& reflectedEnergies) const;
-
-private:
-  G4int verboseLevel;			// For diagnostic messages
-  mutable G4bool keepAllPhonons;	// Copy of flag KeepKaplanPhonons()
-
-  G4MaterialPropertiesTable* filmProperties;
-  G4double filmThickness;	// Quantities extracted from properties table
-  G4double gapEnergy;		// Bandgap energy (delta)
-  G4double lowQPLimit;		// Minimum X*delta to keep as a quasiparticle
-  G4double highQPLimit;		// Maximum X*delta to create QP from phonon
-  G4double directAbsorption;	// Probability to collect energy directly (TES)
-  G4double absorberGap;		// Bandgap of secondary absorber material
-  G4double absorberEff;         // Quasiparticle absorption efficiency
-  G4double absorberEffSlope;    // Energy dependence of qp absorption efficiency
-  G4double phononLifetime;	// Lifetime of phonons in film at 2*delta
-  G4double phononLifetimeSlope;	// Energy dependence of phonon lifetime
-  G4double vSound;		// Speed of sound in film
-  G4double temperature;		// Ambient temperature of film (from lattice)
-
-  // Temporary buffers for use within processing functions
-  mutable std::vector<G4double> qpEnergyList;	// Active ("final") population
-  mutable std::vector<G4double> phononEnergyList;
-  mutable std::vector<G4double> newQPEnergies;	// Intermediate processing
-  mutable std::vector<G4double> newPhonEnergies;
-
-  mutable std::ofstream output;		// Diagnostic output under G4CMP_DEBUG
-};
+  virtual G4double CalcQPEfficiency(G4double qpE) const override;
+}; // class G4CMPKaplanQP
 
 #endif	/* G4CMPKaplanQP_hh */

--- a/library/include/G4CMPPhononElectrode.hh
+++ b/library/include/G4CMPPhononElectrode.hh
@@ -35,6 +35,8 @@
 // 
 // 20221006  M. Kelsey -- Adapted from SuperCDMS simulation version
 // 20260710  G4CMP-647 -- Replace G4CMPKaplanQP member with G4CMPVKaplanQP
+// 20260710  G4CMP-647 -- Add RegisterAbsorber method to enable user
+// customization
 
 #ifndef G4CMPPhononElectrode_hh
 #define G4CMPPhononElectrode_hh 1
@@ -90,8 +92,8 @@ protected:
   // NOTE: "Mutable" because AbsorbAtElectrode() function is const
   mutable G4CMPVKaplanQP* kaplanQP;	// Create instance of QET simulator
   mutable std::vector<G4double> phononEnergies;		// Reusable buffer
-  mutable G4bool absorberSet; // so we can tell if user has set kaplanQP to nullptr
-  // intentionally
+  mutable G4bool absorberSet; // so we can tell if user has set kaplanQP to
+  // nullptr intentionally
 };
 
 #endif

--- a/library/include/G4CMPPhononElectrode.hh
+++ b/library/include/G4CMPPhononElectrode.hh
@@ -34,13 +34,14 @@
 /// directly absorb phonons below 2*bandgap.
 // 
 // 20221006  M. Kelsey -- Adapted from SuperCDMS simulation version
+// 20260710  G4CMP-647 -- Replace G4CMPKaplanQP member with G4CMPVKaplanQP
 
 #ifndef G4CMPPhononElectrode_hh
 #define G4CMPPhononElectrode_hh 1
 
 #include "G4CMPVElectrodePattern.hh"
 
-class G4CMPKaplanQP;
+class G4CMPVKaplanQP;
 class G4ParticleChange;
 class G4Step;
 class G4Track;
@@ -67,7 +68,7 @@ public:
   virtual void AbsorbAtElectrode(const G4Track&,
                                  const G4Step&,
                                  G4ParticleChange&) const;
-
+  G4CMPVKaplanQP* getKaplanQP(G4String identifier = "") const;
 protected:
   // Record energy deposition and re-emitted energies as secondary phonons
   void ProcessAbsorption(const G4Track& track, const G4Step& step,
@@ -78,7 +79,7 @@ protected:
 			 G4ParticleChange& particleChange) const;
 
   // NOTE: "Mutable" because AbsorbAtElectrode() function is const
-  mutable G4CMPKaplanQP* kaplanQP;	// Create instance of QET simulator
+  mutable G4CMPVKaplanQP* kaplanQP;	// Create instance of QET simulator
   mutable std::vector<G4double> phononEnergies;		// Reusable buffer
 };
 

--- a/library/include/G4CMPPhononElectrode.hh
+++ b/library/include/G4CMPPhononElectrode.hh
@@ -68,8 +68,17 @@ public:
   virtual void AbsorbAtElectrode(const G4Track&,
                                  const G4Step&,
                                  G4ParticleChange&) const;
+  // define phonon-qp interaction mechanism via string identifier;
+  // G4CMPKaplanQP default
   G4CMPVKaplanQP* getKaplanQP(G4String identifier = "") const;
+  // define phonon-qp interaction mechanism directly
+  // NOTE: PhononElectrode object will take ownership of absorber object
+  // and eventually delete it
+  virtual void RegisterAbsorber(G4CMPVKaplanQP* absorber) const { setKaplanQP(absorber); }
+  // use getKaplanQP to register absorber
+  virtual void RegisterAbsorber(const G4String& identifier) const  { RegisterAbsorber(getKaplanQP(identifier)); }
 protected:
+  virtual void setKaplanQP(G4CMPVKaplanQP* val) const;
   // Record energy deposition and re-emitted energies as secondary phonons
   void ProcessAbsorption(const G4Track& track, const G4Step& step,
 			 G4double EDep, G4ParticleChange& particleChange) const;
@@ -81,6 +90,8 @@ protected:
   // NOTE: "Mutable" because AbsorbAtElectrode() function is const
   mutable G4CMPVKaplanQP* kaplanQP;	// Create instance of QET simulator
   mutable std::vector<G4double> phononEnergies;		// Reusable buffer
+  mutable G4bool absorberSet; // so we can tell if user has set kaplanQP to nullptr
+  // intentionally
 };
 
 #endif

--- a/library/include/G4CMPVKaplanQP.hh
+++ b/library/include/G4CMPVKaplanQP.hh
@@ -1,0 +1,168 @@
+/***********************************************************************\
+ * This software is licensed under the terms of the GNU General Public *
+ * License version 3 or later. See G4CMP/LICENSE for the full license. *
+\***********************************************************************/
+
+/// \file library/include/G4CMPVKaplanQP.hh
+/// \brief Grouping of free standing functions that relate to the
+/// creation and energy calculations of quasi-particle downconversion
+/// by phonons breaking Cooper pairs in superconductors.
+///
+/// This code implements a "lumped" version of Kaplan's model for
+/// quasiparticle-phonon interactions in superconducting films,
+/// S.B.Kaplan et al., Phys.Rev.B14 (1976).
+///
+/// If the thin-film parameters are set from a MaterialPropertiesTable,
+/// the table must contain the first five of the following entries:
+///
+/// | Property Key        | Definition                   | Example value (Al) |
+/// |---------------------|------------------------------|--------------------|
+/// | filmThickness       | Thickness of film            | 600.*nm            |
+/// | vSound              | Speed of sound in film       | 3.26*km/s          |
+/// | gapEnergy           | Bandgap of film material     | 173.715e-6*eV      |
+/// | phononLifetime      | Phonon lifetime at 2*bandgap | 242.*ps            |
+/// | phononLifetimeSlope | Lifetime vs. energy          | 0.29               |
+/// |                     |                              |                    |
+/// | lowQPLimit          | Minimum QP energy to radiate phonons | 3.         |
+/// | highQPLimit         | Maximum energy to create QPs | 10.                |
+/// | subgapAbsorption    | Absorption below 2*bandgap   | 0.03 (optional)    |
+/// | absorberGap         | Bandgap of "subgap absorber" | 15e-6*eV (W)       |
+/// | absorberEff         | QP absorption efficiency     | 0.3                |
+/// | absorberEffSlope    | Efficiency vs. energy        | 0.                 |
+/// | temperature         | Temperature of film          | 0.05e-3*K          |
+//
+// $Id$
+//
+// 20260710  G4CMP-647 -- Implement virtual base class for phonon-qp
+// interactions
+
+#ifndef G4CMPVKaplanQP_hh
+#define G4CMPVKaplanQP_hh 1
+
+#include "G4Types.hh"
+#include <fstream>
+#include <vector>
+
+class G4MaterialPropertiesTable;
+
+class G4CMPVKaplanQP {
+public:
+  G4CMPVKaplanQP(G4MaterialPropertiesTable* prop, G4int vb=0);
+  ~G4CMPVKaplanQP();
+
+  // Turn on diagnostic messages
+  void SetVerboseLevel(G4int vb) { verboseLevel = vb; }
+  G4int GetVerboseLevel() const { return verboseLevel; }
+
+  // Set temperature for use by thermalization functions
+  void SetTemperature(G4double temp) { temperature = temp; }
+
+  // Configure thin film (QET, metalization, etc.) for phonon absorption
+  void SetFilmProperties(G4MaterialPropertiesTable* prop);
+
+  // Alternative configuration without properties table
+  void SetFilmThickness(G4double value)       { filmThickness = value; }
+  void SetGapEnergy(G4double value)           { gapEnergy = value; }
+  void SetLowQPLimit(G4double value)          { lowQPLimit = value; }
+  void SetHighQPLimit(G4double value)         { highQPLimit = value; }
+  void SetSubgapAbsorption(G4double value)    { directAbsorption = value; }
+  void SetDirectAbsorption(G4double value)    { directAbsorption = value; }
+  void SetAbsorberGap(G4double value)         { absorberGap = value; }
+  void SetAbsorberEff(G4double value)         { absorberEff = value; }
+  void SetAbsorberEffSlope(G4double value)    { absorberEffSlope = value; }
+  void SetPhononLifetime(G4double value)      { phononLifetime = value; }
+  void SetPhononLifetimeSlope(G4double value) { phononLifetimeSlope = value; }
+  void SetVSound(G4double value)              { vSound = value; }
+
+  // Do absorption on sensor/metalization film
+  // Returns absorbed energy, fills list of re-emitted phonons
+  virtual G4double AbsorbPhonon(G4double energy,
+      std::vector<G4double>& reflectedEnergies) const = 0;
+
+protected:
+  // Check that the five required parameters are set to meaningful values
+  G4bool ParamsReady() const {
+    return (filmThickness > 0. && gapEnergy >= 0. && vSound > 0. &&
+      phononLifetime > 0. && phononLifetimeSlope >= 0.);
+  }
+
+  // Compute the probability of a phonon reentering the crystal without breaking
+  // any Cooper pairs.
+  virtual G4double CalcEscapeProbability(G4double energy,
+         G4double thicknessFrac) const = 0;
+
+  // Model the phonons (phonEnergies) breaking Cooper pairs into quasiparticles
+  // (qpEnergies).
+  virtual G4double CalcQPEnergies(std::vector<G4double>& phonEnergies,
+        std::vector<G4double>& qpEnergies) const = 0;
+  
+  // Model the quasiparticles (qpEnergies) emitting phonons (phonEnergies) in
+  // the superconductor.
+  virtual G4double CalcPhononEnergies(std::vector<G4double>& phonEnergies,
+            std::vector<G4double>& qpEnergies) const = 0;
+  
+  // Calculate energies of phonon tracks that have reentered the crystal.
+  virtual void CalcReflectedPhononEnergies(std::vector<G4double>& phonEnergies,
+           std::vector<G4double>& reflectedEnergies) const = 0;
+
+  // Compute probability of phonon collection directly on absorber (TES)
+  virtual G4bool DoDirectAbsorption(G4double energy) const = 0;
+  virtual G4double CalcDirectAbsorption(G4double energy,
+        std::vector<G4double>& keepEnergies) const = 0;
+
+  // Handle absorption of quasiparticle energies below Cooper-pair breaking
+  // If qpEnergy < 3*Delta, radiate a phonon, absorb bandgap minimum
+  virtual G4double CalcQPAbsorption(G4double energy,
+          std::vector<G4double>& phonEnergies,
+          std::vector<G4double>& qpEnergies) const = 0;
+          
+  // Handle quasiparticle energy-dependent absorption efficiency
+  virtual G4double CalcQPEfficiency(G4double qpE) const = 0;
+
+  // Compute quasiparticle energy distribution from broken Cooper pair.
+  G4double QPEnergyRand(G4double Energy) const;
+  G4double QPEnergyPDF(G4double E, G4double x) const;
+  G4double ThermalPDF(G4double E) const;
+
+  // Compute phonon energy distribution from quasiparticle in superconductor.
+  G4double PhononEnergyRand(G4double Energy) const;
+  G4double PhononEnergyPDF(G4double E, G4double x) const;
+
+  // Encapsulate below-bandgap logic
+  G4bool IsSubgap(G4double energy) const { return (energy < 2.*gapEnergy); }
+  G4bool DirectAbsorb(G4double energy) const {
+    return (IsSubgap(energy) && energy > 2.*absorberGap);
+  }
+
+  // Write summary of interaction to output "kaplanqp_stats" file
+  void ReportAbsorption(G4double energy, G4double EDep,
+      const std::vector<G4double>& reflectedEnergies) const;
+
+protected:
+  G4int verboseLevel;     // For diagnostic messages
+  mutable G4bool keepAllPhonons;  // Copy of flag KeepKaplanPhonons()
+
+  G4MaterialPropertiesTable* filmProperties;
+  G4double filmThickness; // Quantities extracted from properties table
+  G4double gapEnergy;   // Bandgap energy (delta)
+  G4double lowQPLimit;    // Minimum X*delta to keep as a quasiparticle
+  G4double highQPLimit;   // Maximum X*delta to create QP from phonon
+  G4double directAbsorption;  // Probability to collect energy directly (TES)
+  G4double absorberGap;   // Bandgap of secondary absorber material
+  G4double absorberEff;         // Quasiparticle absorption efficiency
+  G4double absorberEffSlope;    // Energy dependence of qp absorption efficiency
+  G4double phononLifetime;  // Lifetime of phonons in film at 2*delta
+  G4double phononLifetimeSlope; // Energy dependence of phonon lifetime
+  G4double vSound;    // Speed of sound in film
+  G4double temperature;   // Ambient temperature of film (from lattice)
+
+  // Temporary buffers for use within processing functions
+  mutable std::vector<G4double> qpEnergyList; // Active ("final") population
+  mutable std::vector<G4double> phononEnergyList;
+  mutable std::vector<G4double> newQPEnergies;  // Intermediate processing
+  mutable std::vector<G4double> newPhonEnergies;
+
+  mutable std::ofstream output;   // Diagnostic output under G4CMP_DEBUG
+}; // class G4CMPVKaplanQP
+
+#endif  /* G4CMPVKaplanQP_hh */

--- a/library/include/G4CMPVKaplanQP.hh
+++ b/library/include/G4CMPVKaplanQP.hh
@@ -4,13 +4,11 @@
 \***********************************************************************/
 
 /// \file library/include/G4CMPVKaplanQP.hh
-/// \brief Grouping of free standing functions that relate to the
-/// creation and energy calculations of quasi-particle downconversion
-/// by phonons breaking Cooper pairs in superconductors.
+/// \brief Base class for phonon-qp interaction physics
 ///
-/// This code implements a "lumped" version of Kaplan's model for
-/// quasiparticle-phonon interactions in superconducting films,
-/// S.B.Kaplan et al., Phys.Rev.B14 (1976).
+/// This code implements a base class to control the properties of
+/// phonon-qp interactions. Most of the code is extracted from the original
+/// G4CMPKaplanQP implementation.
 ///
 /// If the thin-film parameters are set from a MaterialPropertiesTable,
 /// the table must contain the first five of the following entries:

--- a/library/src/G4CMPConfigManager.cc
+++ b/library/src/G4CMPConfigManager.cc
@@ -205,14 +205,16 @@ void G4CMPConfigManager::setVersion() {
 
 G4int G4CMPConfigManager::setPhysicsModelID() const {
 #if G4VERSION_NUMBER < 1100
-  G4PhysicsModelCatalog::Register("G4CMP process");
+  return G4PhysicsModelCatalog::Register("G4CMP process");
 #elif G4VERSION_NUMBER < 1142
   G4PhysicsModelCatalog::Initialize();	// Uses G4CMP local hack of function
+  return G4PhysicsModelCatalog::GetModelID("G4CMP process");
 #else
   G4PhysicsModelCatalog::RegisterCustomModel("G4CMP process");
+  return G4PhysicsModelCatalog::GetModelID("G4CMP process");
 #endif
 
-  return G4PhysicsModelCatalog::GetModelID("G4CMP process");
+  return 0;		// Should never get here
 }
 
 

--- a/library/src/G4CMPConfigManager.cc
+++ b/library/src/G4CMPConfigManager.cc
@@ -53,6 +53,7 @@
 // 20260121  G4CMP-567: Change charge bounces default to zero.
 // 20260429  G4CMP-598: Add minGenParticles parameter.
 // 20260606  G4CMP-578: Add primaryPhononEnergy parameter for partitioning.
+// 20260707  G4CMP-641: Use new RegisterCustomModel() for Physics in G4 11.4.2+
 
 #include "G4CMPConfigManager.hh"
 #include "G4CMPConfigMessenger.hh"
@@ -204,11 +205,14 @@ void G4CMPConfigManager::setVersion() {
 
 G4int G4CMPConfigManager::setPhysicsModelID() const {
 #if G4VERSION_NUMBER < 1100
-  return G4PhysicsModelCatalog::Register("G4CMP process");
+  G4PhysicsModelCatalog::Register("G4CMP process");
+#elif G4VERSION_NUMBER < 1142
+  G4PhysicsModelCatalog::Initialize();	// Uses G4CMP local hack of function
 #else
-  G4PhysicsModelCatalog::Initialize();
-  return G4PhysicsModelCatalog::GetModelID("G4CMP process");
+  G4PhysicsModelCatalog::RegisterCustomModel("G4CMP process");
 #endif
+
+  return G4PhysicsModelCatalog::GetModelID("G4CMP process");
 }
 
 

--- a/library/src/G4CMPGeometryUtils.cc
+++ b/library/src/G4CMPGeometryUtils.cc
@@ -18,6 +18,7 @@
 //		to specified direction.
 // 20250905  G4CMP-500 -- Added a function to make nicer robust 2D vectors
 // 20260111  G4CMP-567 -- Use geometric tolerance prescribed by G4VSolid
+// 20260721  G4CMP-649 -- Protect against missing touchable in SurfaceClearance.
 
 #include "G4CMPGeometryUtils.hh"
 #include "G4CMPConfigManager.hh"
@@ -1049,6 +1050,14 @@ G4VTouchable* G4CMP::CreateTouchableAtPoint(const G4ThreeVector& pos) {
 
 G4ThreeVector G4CMP::ApplySurfaceClearance(const G4VTouchable* touch,
 					   G4ThreeVector pos) {
+  if (!touch) {
+    G4ExceptionDescription msg;
+    msg << "Missing touchable: not supplied for position " << pos;
+    G4Exception("G4CMP::ApplySurfaceClearance", "Geometry011",
+		EventMustBeAborted, msg);
+    return pos;
+  }
+
   // Clearance is the minimum distance where a position is guaranteed Inside
   const G4double clearance = G4CMPConfigManager::GetSurfaceClearance();
 
@@ -1061,7 +1070,7 @@ G4ThreeVector G4CMP::ApplySurfaceClearance(const G4VTouchable* touch,
     if (!lat) {
       G4ExceptionDescription msg;
       msg << "Position " << pos << " not associated with valid volume.";
-      G4Exception("G4CMP::CreateSecondary", "Secondary008",
+      G4Exception("G4CMP::ApplySurfaceClearance", "Geometry012",
 		  EventMustBeAborted, msg);
       return pos;
     }

--- a/library/src/G4CMPHitMerging.cc
+++ b/library/src/G4CMPHitMerging.cc
@@ -21,6 +21,8 @@
 //	       If not preset, then call UsePosition() in ProcessStep().
 // 20240822  G4CMP-423 -- In UsePosition(), take midpoint of step to avoid
 //	       boundary surfaces.
+// 20240721  G4CMP-649 -- In SurfaceClearance(), create touchable from
+//		position if not available
 
 #include "G4CMPHitMerging.hh"
 #include "G4CMPConfigManager.hh"
@@ -451,5 +453,16 @@ void G4CMPHitMerging::GeneratePositions(size_t nsec,
 
 G4ThreeVector 
 G4CMPHitMerging::SurfaceClearance(const G4ThreeVector& pos) {
-  return G4CMP::ApplySurfaceClearance(GetCurrentTouchable(), pos);
+  const G4VTouchable* touch = GetCurrentTouchable();
+  G4ThreeVector clear;
+
+  if (touch) clear = G4CMP::ApplySurfaceClearance(touch, pos);
+  else {
+    // Preset touchable not set, get one based on position
+    touch = G4CMP::CreateTouchableAtPoint(pos);
+    clear = G4CMP::ApplySurfaceClearance(touch, pos);
+    delete touch;
+  }
+
+  return clear;
 }

--- a/library/src/G4CMPKaplanQP.cc
+++ b/library/src/G4CMPKaplanQP.cc
@@ -68,6 +68,7 @@
 //		Add Fermi-Dirac occupation statistics for QP energy spectrum.
 // 20250101  G4CMP-439: Create separate debugging file per worker thread;
 //		add EventID and TrackID columns to debugging output.
+// 20260710  G4CMP-647 -- Derive from new base class G4CMPVKaplanQP
 
 #include "globals.hh"
 #include "G4CMPKaplanQP.hh"
@@ -75,14 +76,12 @@
 #include "G4CMPUtils.hh"
 #include "G4Event.hh"
 #include "G4EventManager.hh"
-#include "G4MaterialPropertiesTable.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4RunManager.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4TrackingManager.hh"
 #include "G4Track.hh"
 #include "Randomize.hh"
-#include <numeric>
 
 
 // Global function for Kaplan quasiparticle downconversion.  Retained here
@@ -105,78 +104,9 @@ G4double G4CMP::KaplanPhononQP(G4double energy,
 // Class constructor and destructor
 
 G4CMPKaplanQP::G4CMPKaplanQP(G4MaterialPropertiesTable* prop, G4int vb)
-  : verboseLevel(vb), keepAllPhonons(true),
-    filmProperties(0), filmThickness(0.), gapEnergy(0.),
-    lowQPLimit(3.), highQPLimit(0.), directAbsorption(0.), absorberGap(0.),
-    absorberEff(1.), absorberEffSlope(0.), phononLifetime(0.), 
-    phononLifetimeSlope(0.), vSound(0.), temperature(0.) {
+  : G4CMPVKaplanQP(prop, vb) {
   if (prop) SetFilmProperties(prop);
 }
-
-G4CMPKaplanQP::~G4CMPKaplanQP() {
-#ifdef G4CMP_DEBUG
-  if (output.is_open()) output.close();
-#endif
-}
-
-// Configure thin film (QET, metalization, etc.) for phonon absorption
-
-void G4CMPKaplanQP::SetFilmProperties(G4MaterialPropertiesTable* prop) {
-  if (!prop) {
-    G4Exception("G4CMPKaplanQP::SetFilmProperties()", "G4CMP001",
-                RunMustBeAborted, "Null MaterialPropertiesTable vector.");
-  }
-
-  // Check that the MaterialPropertiesTable has everything we need. If it came
-  // from a G4CMPSurfaceProperty, then it will be fine.
-  if (!(prop->ConstPropertyExists("gapEnergy") &&
-        prop->ConstPropertyExists("phononLifetime") &&
-        prop->ConstPropertyExists("phononLifetimeSlope") &&
-        prop->ConstPropertyExists("vSound") &&
-        prop->ConstPropertyExists("filmThickness"))) {
-    G4Exception("G4CMPKaplanQP::SetFilmProperties()", "G4CMP002",
-		RunMustBeAborted,
-                "Insufficient info in MaterialPropertiesTable.");
-  }
-
-  // Extract values from table here for convenience in functions
-  if (filmProperties != prop) {
-    filmThickness =       prop->GetConstProperty("filmThickness");
-    gapEnergy =           prop->GetConstProperty("gapEnergy");
-    phononLifetime =      prop->GetConstProperty("phononLifetime");
-    phononLifetimeSlope = prop->GetConstProperty("phononLifetimeSlope");
-    vSound =              prop->GetConstProperty("vSound");
-
-    absorberEff =      (prop->ConstPropertyExists("absorberEff")
-			  ? prop->GetConstProperty("absorberEff") : 1.);
-
-    absorberEffSlope = (prop->ConstPropertyExists("absorberEffSlope")
-			  ? prop->GetConstProperty("absorberEffSlope"): 0.);
-
-    lowQPLimit =       (prop->ConstPropertyExists("lowQPLimit")
-			? prop->GetConstProperty("lowQPLimit") : 3.);
-
-    highQPLimit =      (prop->ConstPropertyExists("highQPLimit")
-			? prop->GetConstProperty("highQPLimit") : 0.);
-
-    // Backward compatible -- support both old "subgap" and new "direct" names
-    directAbsorption = (prop->ConstPropertyExists("directAbsorption")
-			? prop->GetConstProperty("directAbsorption")
-			: (prop->ConstPropertyExists("subgapAbsorption")
-			   ? prop->GetConstProperty("subgapAbsorption") : 0.)
-			);
-
-    absorberGap =      (prop->ConstPropertyExists("absorberGap")
-			? prop->GetConstProperty("absorberGap") : 0.);
-
-    temperature =      (prop->ConstPropertyExists("temperature")
-			? prop->GetConstProperty("temperature")
-			: G4CMPConfigManager::GetTemperature() );
-
-    filmProperties = prop;
-  }
-}
-
 
 // This is the main function for the Kaplan quasiparticle downconversion
 // process. Based on the energy of the incoming phonon and the properties
@@ -272,35 +202,6 @@ AbsorbPhonon(G4double energy, std::vector<G4double>& reflectedEnergies) const {
   ReportAbsorption(energy, EDep, reflectedEnergies);
 
   return EDep;
-}
-
-void G4CMPKaplanQP::
-ReportAbsorption(G4double energy, G4double EDep,
-		 const std::vector<G4double>& reflectedEnergies) const {
-  G4double ERefl = std::accumulate(reflectedEnergies.begin(),
-				   reflectedEnergies.end(), 0.);
-
-#ifdef G4CMP_DEBUG
-  if (output.good()) {
-    output << energy/eV << "," << EDep/eV << "," << ERefl/eV << ","
-	   << reflectedEnergies.size() << std::endl;
-  }
-#endif
-
-  G4double delta = energy-ERefl-EDep;
-  if (fabs(delta) < 1e-20) delta = 0.;	// Suppress floating-point fluctuation
-
-  if (verboseLevel>1) {
-    G4cout << " Phonon " << energy/eV << " deposited " << EDep/eV
-	   << " reflected " << ERefl/eV << " as " << reflectedEnergies.size()
-	   << " new phonons " << delta/eV << " eV lost"
-	   << G4endl;
-  }
-
-  if (delta < 0.) {		// Actual energy excess
-    G4cerr << "WARNING G4CMPKaplanQP has excess " << delta/eV << " eV"
-	   << " above incident phonon." << G4endl;
-  }
 }
 
 // Compute the probability of phonon reentering the crystal without breaking
@@ -516,78 +417,4 @@ G4double G4CMPKaplanQP::CalcQPEfficiency(G4double qpE) const {
   }
 
   return eff;
-}
-
-
-// Compute quasiparticle energy distribution from broken Cooper pair.
-
-G4double G4CMPKaplanQP::QPEnergyRand(G4double Energy) const {
-  // PDF is not integrable, so we can't do an inverse transform sampling.
-  // Instead, we'll do a rejection method.
-  //
-  // PDF(E') = (E'*(Energy - E') + gapEnergy*gapEnergy)
-  //           /
-  //           sqrt((E'*E' - gapEnergy*gapEnergy) *
-  //                ((Energy - E')*(Energy - E') - gapEnergy*gapEnergy));
-  // The shape of the PDF is like a U, so the max values are at the endpoints:
-  // E' = gapEnergy and E' = Energy - gapEnergy
-
-  // Add buffer so first/last bins don't give zero denominator in pdfSum
-  const G4double BUFF = 1000.;
-  G4double xmin = gapEnergy + (Energy-2.*gapEnergy)/BUFF;
-  G4double xmax = gapEnergy + (Energy-2.*gapEnergy)*(BUFF-1.)/BUFF;
-  G4double ymax = QPEnergyPDF(Energy, xmin);
-
-  G4double xtest=0., ytest=ymax;
-  do {
-    ytest = G4UniformRand()*ymax;
-    xtest = G4UniformRand()*(xmax-xmin) + xmin;
-  } while (ytest > QPEnergyPDF(Energy, xtest));
-
-  return xtest;
-}
-
-G4double G4CMPKaplanQP::QPEnergyPDF(G4double E, G4double x) const {
-  const G4double gapsq = gapEnergy*gapEnergy;
-  const G4double occupy = 1. - ThermalPDF(E) - ThermalPDF(E-x);
-
-  return ( occupy * (x*(E-x)+gapsq) / sqrt((x*x-gapsq) * ((E-x)*(E-x)-gapsq)) );
-}
-
-G4double G4CMPKaplanQP::ThermalPDF(G4double E) const {
-  const G4double kT = k_Boltzmann*temperature;
-  return ( (temperature > 0.) ? 1./(exp(E/kT)+1.) : 0. );
-}
-
-
-// Compute phonon energy distribution from quasiparticle in superconductor.
-// NOTE:  Technically, this is the energy of the QP after emission; the
-//        phonon's own energy is Ephonon = Energy - E', below
-
-G4double G4CMPKaplanQP::PhononEnergyRand(G4double Energy) const {
-  // PDF is not integrable, so we can't do an inverse transform sampling.
-  // Instead, we'll do a rejection method.
-  //
-  // PDF(E') = ((Energy-E')*(Energy-E') * (E'-gapEnergy*gapEnergy/Energy))
-  //           /
-  //           sqrt((E'*E' - gapEnergy*gapEnergy);
-
-  // Add buffer so first bin doesn't give zero denominator in pdfSum
-  const G4double BUFF = 1000.;
-  G4double xmin = gapEnergy + gapEnergy/BUFF;
-  G4double xmax = Energy;
-  G4double ymax = PhononEnergyPDF(Energy, xmin);
-
-  G4double xtest=0., ytest=ymax;
-  do {
-    ytest = G4UniformRand()*ymax;
-    xtest = G4UniformRand()*(xmax-xmin) + xmin;
-  } while (ytest > PhononEnergyPDF(Energy, xtest));
-
-  return Energy-xtest;
-}
-
-G4double G4CMPKaplanQP::PhononEnergyPDF(G4double E, G4double x) const {
-  const G4double gapsq = gapEnergy*gapEnergy;
-  return ( (E-x)*(E-x) * (x-gapsq/E) / sqrt(x*x - gapsq) );
 }

--- a/library/src/G4CMPKaplanQP.cc
+++ b/library/src/G4CMPKaplanQP.cc
@@ -170,7 +170,7 @@ AbsorbPhonon(G4double energy, std::vector<G4double>& reflectedEnergies) const {
 
   // Divide incident phonon according to maximum QP energy (or no split)
   G4int nQPpairs =
-    (highQPLimit>0. ? std::ceil(energy/(2.*highQPLimit*gapEnergy)) : 1);
+    (highQPLimit>0. && gapEnergy > 0. ? std::ceil(energy/(2.*highQPLimit*gapEnergy)) : 1);
 
   // Initialize event buffers for new processing
   qpEnergyList.clear();
@@ -409,7 +409,7 @@ G4CMPKaplanQP::CalcQPAbsorption(G4double qpE,
 // Handle quasiparticle energy-dependent absorption efficiency
 
 G4double G4CMPKaplanQP::CalcQPEfficiency(G4double qpE) const {
-  G4double eff = absorberEff + absorberEffSlope * qpE/gapEnergy;
+  G4double eff = absorberEff + absorberEffSlope * gapEnergy > 0. ? qpE/gapEnergy : 1.;
   eff = std::max(0., std::min(eff, 1.));
 
   if (verboseLevel>2) {

--- a/library/src/G4CMPPhononElectrode.cc
+++ b/library/src/G4CMPPhononElectrode.cc
@@ -41,6 +41,7 @@
 // 20251115  G4CMP-539 -- Replace AddConstProperty() with UpdateMPT().
 // 20260212  G4CMP-581 -- Skip invalid phonons (null pointers), report skips.
 // 20260218  G4CMP-588 -- Fix change above by presenting secondary buffer.
+// 20260710  G4CMP-647 -- Replace G4CMPKaplanQP member with G4CMPVKaplanQP
 
 #include "G4CMPPhononElectrode.hh"
 #include "G4CMPGeometryUtils.hh"
@@ -50,6 +51,7 @@
 #include "G4CMPSurfaceProperty.hh"
 #include "G4CMPTrackUtils.hh"
 #include "G4CMPUtils.hh"
+#include "G4CMPVKaplanQP.hh"
 #include "G4Exception.hh"
 #include "G4ExceptionSeverity.hh"
 #include "G4LatticeManager.hh"
@@ -94,12 +96,17 @@ AbsorbAtElectrode(const G4Track& track, const G4Step& step,
 
   // Create KaplanQP simulator if not already available
   if (!kaplanQP) {
-    // Pass temperture through to KaplanQP if no already included
+    // Pass temperature through to KaplanQP if not already included
     if (!theSurfaceTable->ConstPropertyExists("temperature"))
       G4CMP::UpdateMPT(theSurfaceTable, "temperature",
 		       theLattice->GetTemperature());
 
-    kaplanQP = new G4CMPKaplanQP(theSurfaceTable, verboseLevel);
+    // not specifying identity of phonon-qp interaction model here
+    // if other interaction models are added, we will want to make a config
+    // parameter that will get passed in here so the user can specify
+    // the model to be used from a macro command
+    G4String interaction_model;
+    kaplanQP = getKaplanQP(interaction_model);
   }
 
   // Transfer phonon energy into superconducting film
@@ -138,9 +145,9 @@ ProcessAbsorption(const G4Track& track, const G4Step& step, G4double EDep,
   particleChange.ProposeNonIonizingEnergyDeposit(EDep);
 
   // Secondaries are emitted with cos(theta) distribution inward
-  //We'll need to eventually calculate the generalized surface norm
-  //based on the above surface norm and the track's velocity, so
-  //give track velocity
+  // We'll need to eventually calculate the generalized surface norm
+  // based on the above surface norm and the track's velocity, so
+  // give track velocity
   G4ThreeVector vDir = track.GetMomentumDirection();
   G4ThreeVector surfNorm = G4CMP::GetSurfaceNormal(step,vDir);
   
@@ -225,4 +232,15 @@ ProcessReflection(const G4Track& track, const G4Step& step,
 
   auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);
   trackInfo->IncrementReflectionCount();
+}
+
+// define phonon-qp interaction mechanism via string identifier; G4CMPKaplanQP default
+G4CMPVKaplanQP* G4CMPPhononElectrode::getKaplanQP(G4String identifier) const
+{
+  G4CMPVKaplanQP* val = nullptr;
+  if (identifier.empty() || identifier.find("aplan") != G4String::npos)
+  {
+    val = new G4CMPKaplanQP(theSurfaceTable, verboseLevel);
+  }
+  return val;
 }

--- a/library/src/G4CMPPhononElectrode.cc
+++ b/library/src/G4CMPPhononElectrode.cc
@@ -68,7 +68,7 @@
 // Constructor and destructor
 
 G4CMPPhononElectrode::G4CMPPhononElectrode()
-  : G4CMPVElectrodePattern(), kaplanQP(0) {;}
+  : G4CMPVElectrodePattern(), kaplanQP(0), absorberSet(false) {;}
 
 G4CMPPhononElectrode::~G4CMPPhononElectrode() {
   delete kaplanQP; kaplanQP=0;
@@ -95,7 +95,7 @@ AbsorbAtElectrode(const G4Track& track, const G4Step& step,
   }
 
   // Create KaplanQP simulator if not already available
-  if (!kaplanQP) {
+  if (!kaplanQP && !absorberSet) {
     // Pass temperature through to KaplanQP if not already included
     if (!theSurfaceTable->ConstPropertyExists("temperature"))
       G4CMP::UpdateMPT(theSurfaceTable, "temperature",
@@ -106,8 +106,9 @@ AbsorbAtElectrode(const G4Track& track, const G4Step& step,
     // parameter that will get passed in here so the user can specify
     // the model to be used from a macro command
     G4String interaction_model;
-    kaplanQP = getKaplanQP(interaction_model);
+    RegisterAbsorber(interaction_model);
   }
+  else if (!kaplanQP && absorberSet) return;
 
   // Transfer phonon energy into superconducting film
   G4double Ekin = GetKineticEnergy(track);
@@ -234,7 +235,19 @@ ProcessReflection(const G4Track& track, const G4Step& step,
   trackInfo->IncrementReflectionCount();
 }
 
-// define phonon-qp interaction mechanism via string identifier; G4CMPKaplanQP default
+void G4CMPPhononElectrode::setKaplanQP(G4CMPVKaplanQP* val) const
+{
+  if (kaplanQP)
+  {
+    delete kaplanQP;
+    kaplanQP = 0;
+  }
+  kaplanQP = val;
+  absorberSet = true;
+}
+
+// define phonon-qp interaction mechanism via string identifier;
+// G4CMPKaplanQP default
 G4CMPVKaplanQP* G4CMPPhononElectrode::getKaplanQP(G4String identifier) const
 {
   G4CMPVKaplanQP* val = nullptr;

--- a/library/src/G4CMPVKaplanQP.cc
+++ b/library/src/G4CMPVKaplanQP.cc
@@ -1,0 +1,230 @@
+/***********************************************************************\
+ * This software is licensed under the terms of the GNU General Public *
+ * License version 3 or later. See G4CMP/LICENSE for the full license. *
+\***********************************************************************/
+
+/// \file library/src/G4CMPVKaplanQP.cc
+/// \brief Grouping of free standing functions that relate to the
+/// creation and energy calculations of quasi-particle downconversion
+/// by phonons breaking Cooper pairs in superconductors.
+///
+/// This code implements a "lumped" version of Kaplan's model for
+/// quasiparticle-phonon interactions in superconducting films,
+/// S.B.Kaplan et al., Phys.Rev.B14 (1976).
+///
+/// If the thin-film parameters are set from a MaterialPropertiesTable,
+/// the table must contain the first five of the following entries:
+///
+/// | Property Key        | Definition                   | Example value (Al) |
+/// |---------------------|------------------------------|--------------------|
+/// | filmThickness       | Thickness of film            | 600.*nm            |
+/// | vSound              | Speed of sound in film       | 3.26*km/s          |
+/// | gapEnergy           | Bandgap of film material     | 173.715e-6*eV      |
+/// | phononLifetime      | Phonon lifetime at 2*bandgap | 242.*ps            |
+/// | phononLifetimeSlope | Lifetime vs. energy          | 0.29               |
+/// |                     |                              |                    |
+/// | lowQPLimit          | Minimum QP energy to radiate phonons | 3.         |
+/// | highQPLimit         | Maximum energy to create QPs | 10.                |
+/// | subgapAbsorption    | Absorption below 2*bandgap   | 0.03 (optional)    |
+/// | absorberGap         | Bandgap of "subgap absorber" | 15e-6*eV (W)       |
+/// | absorberEff   | QP absorption efficiency     | 0.3          |
+/// | absorberEffSlope    | Efficiency vs. energy        | 0.                 |
+/// | temperature         | Temperature of film          | 0.05e-3*K          |
+//
+// $Id$
+//
+//
+// 20260710  G4CMP-647 -- Implement virtual base class for phonon-qp
+// interactions
+
+#include "globals.hh"
+#include "G4CMPVKaplanQP.hh"
+#include "G4CMPConfigManager.hh"
+#include "G4CMPUtils.hh"
+#include "G4Event.hh"
+#include "G4EventManager.hh"
+#include "G4MaterialPropertiesTable.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4RunManager.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4TrackingManager.hh"
+#include "G4Track.hh"
+#include "Randomize.hh"
+#include <numeric>
+
+// Class constructor and destructor
+
+G4CMPVKaplanQP::G4CMPVKaplanQP(G4MaterialPropertiesTable* prop, G4int vb)
+  : verboseLevel(vb), keepAllPhonons(true),
+    filmProperties(0), filmThickness(0.), gapEnergy(0.),
+    lowQPLimit(3.), highQPLimit(0.), directAbsorption(0.), absorberGap(0.),
+    absorberEff(1.), absorberEffSlope(0.), phononLifetime(0.), 
+    phononLifetimeSlope(0.), vSound(0.), temperature(0.) {
+  if (prop) SetFilmProperties(prop);
+}
+
+G4CMPVKaplanQP::~G4CMPVKaplanQP() {
+#ifdef G4CMP_DEBUG
+  if (output.is_open()) output.close();
+#endif
+}
+
+// Configure thin film (QET, metalization, etc.) for phonon absorption
+
+void G4CMPVKaplanQP::SetFilmProperties(G4MaterialPropertiesTable* prop) {
+  if (!prop) {
+    G4Exception("G4CMPVKaplanQP::SetFilmProperties()", "G4CMP001",
+                RunMustBeAborted, "Null MaterialPropertiesTable vector.");
+  }
+
+  // Check that the MaterialPropertiesTable has everything we need. If it came
+  // from a G4CMPSurfaceProperty, then it will be fine.
+  if (!(prop->ConstPropertyExists("gapEnergy") &&
+        prop->ConstPropertyExists("phononLifetime") &&
+        prop->ConstPropertyExists("phononLifetimeSlope") &&
+        prop->ConstPropertyExists("vSound") &&
+        prop->ConstPropertyExists("filmThickness"))) {
+    G4Exception("G4CMPVKaplanQP::SetFilmProperties()", "G4CMP002",
+    RunMustBeAborted,
+                "Insufficient info in MaterialPropertiesTable.");
+  }
+
+  // Extract values from table here for convenience in functions
+  if (filmProperties != prop) {
+    filmThickness =       prop->GetConstProperty("filmThickness");
+    gapEnergy =           prop->GetConstProperty("gapEnergy");
+    phononLifetime =      prop->GetConstProperty("phononLifetime");
+    phononLifetimeSlope = prop->GetConstProperty("phononLifetimeSlope");
+    vSound =              prop->GetConstProperty("vSound");
+
+    absorberEff =      (prop->ConstPropertyExists("absorberEff")
+        ? prop->GetConstProperty("absorberEff") : 1.);
+
+    absorberEffSlope = (prop->ConstPropertyExists("absorberEffSlope")
+        ? prop->GetConstProperty("absorberEffSlope"): 0.);
+
+    lowQPLimit =       (prop->ConstPropertyExists("lowQPLimit")
+      ? prop->GetConstProperty("lowQPLimit") : 3.);
+
+    highQPLimit =      (prop->ConstPropertyExists("highQPLimit")
+      ? prop->GetConstProperty("highQPLimit") : 0.);
+
+    // Backward compatible -- support both old "subgap" and new "direct" names
+    directAbsorption = (prop->ConstPropertyExists("directAbsorption")
+      ? prop->GetConstProperty("directAbsorption")
+      : (prop->ConstPropertyExists("subgapAbsorption")
+         ? prop->GetConstProperty("subgapAbsorption") : 0.)
+      );
+
+    absorberGap =      (prop->ConstPropertyExists("absorberGap")
+      ? prop->GetConstProperty("absorberGap") : 0.);
+
+    temperature =      (prop->ConstPropertyExists("temperature")
+      ? prop->GetConstProperty("temperature")
+      : G4CMPConfigManager::GetTemperature() );
+
+    filmProperties = prop;
+  }
+}
+
+void G4CMPVKaplanQP::
+ReportAbsorption(G4double energy, G4double EDep,
+     const std::vector<G4double>& reflectedEnergies) const {
+  G4double ERefl = std::accumulate(reflectedEnergies.begin(),
+           reflectedEnergies.end(), 0.);
+
+#ifdef G4CMP_DEBUG
+  if (output.good()) {
+    output << energy/eV << "," << EDep/eV << "," << ERefl/eV << ","
+     << reflectedEnergies.size() << std::endl;
+  }
+#endif
+
+  G4double delta = energy-ERefl-EDep;
+  if (fabs(delta) < 1e-20) delta = 0.;  // Suppress floating-point fluctuation
+
+  if (verboseLevel>1) {
+    G4cout << " Phonon " << energy/eV << " deposited " << EDep/eV
+     << " reflected " << ERefl/eV << " as " << reflectedEnergies.size()
+     << " new phonons " << delta/eV << " eV lost"
+     << G4endl;
+  }
+
+  if (delta < 0.) {   // Actual energy excess
+    G4cerr << "WARNING G4CMPVKaplanQP has excess " << delta/eV << " eV"
+     << " above incident phonon." << G4endl;
+  }
+}
+
+// Compute quasiparticle energy distribution from broken Cooper pair.
+
+G4double G4CMPVKaplanQP::QPEnergyRand(G4double Energy) const {
+  // PDF is not integrable, so we can't do an inverse transform sampling.
+  // Instead, we'll do a rejection method.
+  //
+  // PDF(E') = (E'*(Energy - E') + gapEnergy*gapEnergy)
+  //           /
+  //           sqrt((E'*E' - gapEnergy*gapEnergy) *
+  //                ((Energy - E')*(Energy - E') - gapEnergy*gapEnergy));
+  // The shape of the PDF is like a U, so the max values are at the endpoints:
+  // E' = gapEnergy and E' = Energy - gapEnergy
+
+  // Add buffer so first/last bins don't give zero denominator in pdfSum
+  const G4double BUFF = 1000.;
+  G4double xmin = gapEnergy + (Energy-2.*gapEnergy)/BUFF;
+  G4double xmax = gapEnergy + (Energy-2.*gapEnergy)*(BUFF-1.)/BUFF;
+  G4double ymax = QPEnergyPDF(Energy, xmin);
+
+  G4double xtest=0., ytest=ymax;
+  do {
+    ytest = G4UniformRand()*ymax;
+    xtest = G4UniformRand()*(xmax-xmin) + xmin;
+  } while (ytest > QPEnergyPDF(Energy, xtest));
+
+  return xtest;
+}
+
+G4double G4CMPVKaplanQP::QPEnergyPDF(G4double E, G4double x) const {
+  const G4double gapsq = gapEnergy*gapEnergy;
+  const G4double occupy = 1. - ThermalPDF(E) - ThermalPDF(E-x);
+
+  return ( occupy * (x*(E-x)+gapsq) / sqrt((x*x-gapsq) * ((E-x)*(E-x)-gapsq)) );
+}
+
+G4double G4CMPVKaplanQP::ThermalPDF(G4double E) const {
+  const G4double kT = k_Boltzmann*temperature;
+  return ( (temperature > 0.) ? 1./(exp(E/kT)+1.) : 0. );
+}
+
+
+// Compute phonon energy distribution from quasiparticle in superconductor.
+// NOTE:  Technically, this is the energy of the QP after emission; the
+//        phonon's own energy is Ephonon = Energy - E', below
+
+G4double G4CMPVKaplanQP::PhononEnergyRand(G4double Energy) const {
+  // PDF is not integrable, so we can't do an inverse transform sampling.
+  // Instead, we'll do a rejection method.
+  //
+  // PDF(E') = ((Energy-E')*(Energy-E') * (E'-gapEnergy*gapEnergy/Energy))
+  //           /
+  //           sqrt((E'*E' - gapEnergy*gapEnergy);
+
+  // Add buffer so first bin doesn't give zero denominator in pdfSum
+  const G4double BUFF = 1000.;
+  G4double xmin = gapEnergy + gapEnergy/BUFF;
+  G4double xmax = Energy;
+  G4double ymax = PhononEnergyPDF(Energy, xmin);
+
+  G4double xtest=0., ytest=ymax;
+  do {
+    ytest = G4UniformRand()*ymax;
+    xtest = G4UniformRand()*(xmax-xmin) + xmin;
+  } while (ytest > PhononEnergyPDF(Energy, xtest));
+
+  return Energy-xtest;
+}
+
+G4double G4CMPVKaplanQP::PhononEnergyPDF(G4double E, G4double x) const {
+  const G4double gapsq = gapEnergy*gapEnergy;
+  return ( (E-x)*(E-x) * (x-gapsq/E) / sqrt(x*x - gapsq) );
+}

--- a/library/src/G4CMPVKaplanQP.cc
+++ b/library/src/G4CMPVKaplanQP.cc
@@ -4,13 +4,11 @@
 \***********************************************************************/
 
 /// \file library/src/G4CMPVKaplanQP.cc
-/// \brief Grouping of free standing functions that relate to the
-/// creation and energy calculations of quasi-particle downconversion
-/// by phonons breaking Cooper pairs in superconductors.
+/// \brief Base class for phonon-qp interaction physics
 ///
-/// This code implements a "lumped" version of Kaplan's model for
-/// quasiparticle-phonon interactions in superconducting films,
-/// S.B.Kaplan et al., Phys.Rev.B14 (1976).
+/// This code implements a base class to control the properties of
+/// phonon-qp interactions. Most of the code is extracted from the original
+/// G4CMPKaplanQP implementation.
 ///
 /// If the thin-film parameters are set from a MaterialPropertiesTable,
 /// the table must contain the first five of the following entries:

--- a/library/src/G4PhysicsModelCatalog.cc
+++ b/library/src/G4PhysicsModelCatalog.cc
@@ -9,10 +9,11 @@
 //
 //  20251116  Michael Kelsey, G4CMP-526
 //  20251125  Change model ID for G4CMP to 39000 to avoid runtime error
+//  20260707  G4CMP-641 -- Only use this hack before G4 11.4.2.
 
 #include "G4Version.hh"
 
-#if G4VERSION_NUMBER >= 1100
+#if 1100 <= G4VERSION_NUMBER && G4VERSION_NUMBER < 1142
 #include "G4PhysicsModelCatalog.hh"
 
 void G4PhysicsModelCatalog::Initialize() {


### PR DESCRIPTION
Adding a base class under G4CMPKaplanQP (G4CMPVKaplanQP) to allow for user-configurable phonon-qp interaction physics. JIRA ticket: https://jira.slac.stanford.edu/browse/G4CMP-647