### PR TITLE
G4CMP-657: Fix typo in specCoeffs in phonon example

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2026-08-16  G4CMP-657 : Fix typo in specCoeffs vector in phonon example.
 2026-08-11  G4CMP-643 : E-field has incorrect HV transform in G4CMPIVRate.
 2026-08-10  G4CMP-654 : Avoid lattice FatalExceptions if no charge parameters.
 2026-08-08  G4CMP-653 : Apply Lindhard yield to steps within HitMerging.

--- a/examples/phonon/src/PhononDetectorConstruction.cc
+++ b/examples/phonon/src/PhononDetectorConstruction.cc
@@ -15,6 +15,7 @@
 //		G4CMPPhononElectrode to demonstrate KaplanQP.
 // 20251116  G4CMP-539 -- Use UpdateMPT wrapper function to set properties.
 // 20251117  G4CMP-541 -- For G4 v11, replace ::Invisible w/::GetInvisible()
+// 20260816  G4CMP-657 -- Fix typo in specCoeffs vector.
 
 #include "PhononDetectorConstruction.hh"
 #include "PhononSensitivity.hh"
@@ -175,7 +176,7 @@ void PhononDetectorConstruction::SetupGeometry()
     const std::vector<G4double> diffCoeffs =
       {5.88e-2, 7.83e-4, -2.47e-6, 1.71e-8, -2.98e-11};
     const std::vector<G4double> specCoeffs =
-      {0,928, -2.03e-4, -3.21e-6, 3.1e-9, 2.9e-13};
+      {0.928, -2.03e-4, -3.21e-6, 3.1e-9, 2.9e-13};
 
     const G4double anhCutoff = 520., reflCutoff = 350.;   // Units external
 


### PR DESCRIPTION
Addressed the typo reported in GitHub issue #95 for the phonon example.